### PR TITLE
Make IframeModal wider on small screens

### DIFF
--- a/src/styles/components/IframeModal.module.scss
+++ b/src/styles/components/IframeModal.module.scss
@@ -19,6 +19,10 @@
 				background-color: var(--color_white);
 				width: 80%;
 				height: 70%;
+				@media screen and (max-width: 767px) {
+					width: 90%;
+				}
+
 				.wrap {
 					display: flex;
 					justify-content: center;


### PR DESCRIPTION
Added a media query to increase the modal width to 90% on screens 767px wide or less, improving mobile responsiveness.